### PR TITLE
Tony/33_filename_dialogue

### DIFF
--- a/lib/src/widgets/button_widget.dart
+++ b/lib/src/widgets/button_widget.dart
@@ -107,10 +107,10 @@ class _ButtonWidgetState extends State<ButtonWidget> {
     final _sliderValues = widget.state['_sliderValues'] as Map<String, double>;
     final _radioValues = widget.state['_radioValues'] as Map<String, String?>;
     final _checkboxValues =
-    widget.state['_checkboxValues'] as Map<String, Set<String>>;
+        widget.state['_checkboxValues'] as Map<String, Set<String>>;
     final _dateValues = widget.state['_dateValues'] as Map<String, DateTime?>;
     final _dropdownValues =
-    widget.state['_dropdownValues'] as Map<String, String?>;
+        widget.state['_dropdownValues'] as Map<String, String?>;
 
     // Add slider values.
 
@@ -137,7 +137,7 @@ class _ButtonWidgetState extends State<ButtonWidget> {
     _dateValues.forEach((key, value) {
       if (value != null) {
         responses[key] =
-        '${value.year}-${value.month.toString().padLeft(2, '0')}-'
+            '${value.year}-${value.month.toString().padLeft(2, '0')}-'
             '${value.day.toString().padLeft(2, '0')}';
       } else {
         responses[key] = null;

--- a/lib/src/widgets/button_widget.dart
+++ b/lib/src/widgets/button_widget.dart
@@ -61,11 +61,15 @@ class _ButtonWidgetState extends State<ButtonWidget> {
   late final String buttonText;
   late final int actionType;
   late final String actionParameter;
+  late TextEditingController _filenameController;
 
   @override
   void initState() {
     super.initState();
     _parseCommand();
+    _filenameController = TextEditingController(
+      text: _generateFilename(widget.surveyTitle),
+    );
   }
 
   void _parseCommand() {
@@ -103,10 +107,10 @@ class _ButtonWidgetState extends State<ButtonWidget> {
     final _sliderValues = widget.state['_sliderValues'] as Map<String, double>;
     final _radioValues = widget.state['_radioValues'] as Map<String, String?>;
     final _checkboxValues =
-        widget.state['_checkboxValues'] as Map<String, Set<String>>;
+    widget.state['_checkboxValues'] as Map<String, Set<String>>;
     final _dateValues = widget.state['_dateValues'] as Map<String, DateTime?>;
     final _dropdownValues =
-        widget.state['_dropdownValues'] as Map<String, String?>;
+    widget.state['_dropdownValues'] as Map<String, String?>;
 
     // Add slider values.
 
@@ -133,7 +137,7 @@ class _ButtonWidgetState extends State<ButtonWidget> {
     _dateValues.forEach((key, value) {
       if (value != null) {
         responses[key] =
-            '${value.year}-${value.month.toString().padLeft(2, '0')}-'
+        '${value.year}-${value.month.toString().padLeft(2, '0')}-'
             '${value.day.toString().padLeft(2, '0')}';
       } else {
         responses[key] = null;
@@ -198,22 +202,62 @@ class _ButtonWidgetState extends State<ButtonWidget> {
       Map<String, dynamic> data, String defaultFileName) async {
     final jsonContent = encoder.convert(data);
 
-    final bytes = utf8.encode(jsonContent);
-    final blob = html.Blob([bytes], 'application/json');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    // Show a dialog to input the filename.
 
-    // Create an anchor element, set its href and download attributes,
-    // and click it.
-
-    html.AnchorElement(href: url)
-      ..setAttribute('download', defaultFileName)
-      ..click();
-
-    html.Url.revokeObjectUrl(url);
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Data downloaded as $defaultFileName')),
+    String? filename = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Save As'),
+          content: TextField(
+            controller: _filenameController,
+            decoration: InputDecoration(
+              hintText: 'Enter filename',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(null);
+              },
+              child: Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(_filenameController.text);
+              },
+              child: Text('Save'),
+            ),
+          ],
+        );
+      },
     );
+
+    if (filename != null && filename.isNotEmpty) {
+      if (!filename.endsWith('.json')) {
+        filename = '$filename.json';
+      }
+      final bytes = utf8.encode(jsonContent);
+      final blob = html.Blob([bytes], 'application/json');
+      final url = html.Url.createObjectUrlFromBlob(blob);
+
+      // Create an anchor element, set its href and download attributes,
+      // and click it.
+
+      html.AnchorElement(href: url)
+        ..setAttribute('download', filename)
+        ..click();
+
+      html.Url.revokeObjectUrl(url);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Data downloaded as $filename')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Save cancelled.')),
+      );
+    }
   }
 
   Future<void> _saveDataForNonWeb(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Added a file name confirmation dialogue before saving data to a local file when using the Chrome browser.

- Link to associated issue: #33

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev