### PR TITLE
Tony/43_radio_button_label

### DIFF
--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -33,10 +33,15 @@ Please select an option from the dropdown menu.
 1. This is Question 1. The following four options belong to the same group.
    Only one option can be selected.
 
-%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
-%% Radio(Question 1,2,Option 2)
-%% Radio(Question 1,3,Option 3)
-%% Radio(Question 1,4,Option 4)
+%% Radio(Question 1,1,"Option 1 This is a long option that may wrap to the next
+line if it needs to. When wrapping it does so indented to align the paragraph.
+This example also demonstrates the use of escape characters, such as \".")
+
+%% Radio(Question 1,2,"Option 2")
+
+%% Radio(Question 1,3,"Option 3")
+
+%% Radio(Question 1,4,"Option 4")
 
 %% EmptyLine
 
@@ -45,33 +50,49 @@ Please select an option from the dropdown menu.
    selections for these two groups are independent and will not affect each 
    other. 
 
-%% Radio(Question 2,1,Option 1)
-%% Radio(Question 2,2,Option 2)
-%% Radio(Question 2,3,Option 3)
-%% Radio(Question 2,4,Option 4)
+%% Radio(Question 2,1,"Option 1")
+
+%% Radio(Question 2,2,"Option 2")
+
+%% Radio(Question 2,3,"Option 3")
+
+%% Radio(Question 2,4,"Option 4")
 
 %% EmptyLine
 
 3. The following are two groups of checkboxes. This is Question 3. Multiple 
    options can be selected.
 
-%% Checkbox(Question 3,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
-%% Checkbox(Question 3,2,Option 2)
-%% Checkbox(Question 3,3,Option 3)
-%% Checkbox(Question 3,4,Option 4)
-%% Checkbox(Question 3,5,Option 5)
-%% Checkbox(Question 3,6,Option 6)
+%% Checkbox(Question 3,1,"Option 1 This is a long option that may wrap to the
+next line if it needs to. When wrapping it does so indented to align the
+paragraph. This example also demonstrates the use of escape characters, such
+as \".")
+
+%% Checkbox(Question 3,2,"Option 2")
+
+%% Checkbox(Question 3,3,"Option 3")
+
+%% Checkbox(Question 3,4,"Option 4")
+
+%% Checkbox(Question 3,5,"Option 5")
+
+%% Checkbox(Question 3,6,"Option 6")
 
 %% EmptyLine
 
 4. This is Question 4. Multiple options can be selected as well.
 
-%% Checkbox(Question 4,1,Option 1)
-%% Checkbox(Question 4,2,Option 2)
-%% Checkbox(Question 4,3,Option 3)
-%% Checkbox(Question 4,4,Option 4)
-%% Checkbox(Question 4,5,Option 5)
-%% Checkbox(Question 4,6,Option 6)
+%% Checkbox(Question 4,1,"Option 1")
+
+%% Checkbox(Question 4,2,"Option 2")
+
+%% Checkbox(Question 4,3,"Option 3")
+
+%% Checkbox(Question 4,4,"Option 4")
+
+%% Checkbox(Question 4,5,"Option 5")
+
+%% Checkbox(Question 4,6,"Option 6")
 
 %% EmptyLine
 

--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -33,7 +33,7 @@ Please select an option from the dropdown menu.
 1. This is Question 1. The following four options belong to the same group.
    Only one option can be selected.
 
-%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.
+%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
 %% Radio(Question 1,2,Option 2)
 %% Radio(Question 1,3,Option 3)
 %% Radio(Question 1,4,Option 4)
@@ -55,7 +55,7 @@ Please select an option from the dropdown menu.
 3. The following are two groups of checkboxes. This is Question 3. Multiple 
    options can be selected.
 
-%% Checkbox(Question 3,1,Option 1 This is a long option that may wrap to the next line. Option 1 This is a long option that may wrap to the next line.)
+%% Checkbox(Question 3,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
 %% Checkbox(Question 3,2,Option 2)
 %% Checkbox(Question 3,3,Option 3)
 %% Checkbox(Question 3,4,Option 4)

--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -33,7 +33,7 @@ Please select an option from the dropdown menu.
 1. This is Question 1. The following four options belong to the same group.
    Only one option can be selected.
 
-%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line. Option 1 This is a long option that may wrap to the next line.)
+%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.
 %% Radio(Question 1,2,Option 2)
 %% Radio(Question 1,3,Option 3)
 %% Radio(Question 1,4,Option 4)

--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -33,7 +33,7 @@ Please select an option from the dropdown menu.
 1. This is Question 1. The following four options belong to the same group.
    Only one option can be selected.
 
-%% Radio(Question 1,1,Option 1)
+%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line. Option 1 This is a long option that may wrap to the next line.)
 %% Radio(Question 1,2,Option 2)
 %% Radio(Question 1,3,Option 3)
 %% Radio(Question 1,4,Option 4)
@@ -55,7 +55,7 @@ Please select an option from the dropdown menu.
 3. The following are two groups of checkboxes. This is Question 3. Multiple 
    options can be selected.
 
-%% Checkbox(Question 3,1,Option 1)
+%% Checkbox(Question 3,1,Option 1 This is a long option that may wrap to the next line. Option 1 This is a long option that may wrap to the next line.)
 %% Checkbox(Question 3,2,Option 2)
 %% Checkbox(Question 3,3,Option 3)
 %% Checkbox(Question 3,4,Option 4)

--- a/lib/src/utils/command_parser.dart
+++ b/lib/src/utils/command_parser.dart
@@ -476,14 +476,22 @@ class CommandParser {
           currentCheckboxOptions = [];
         }
 
-        final radioExp = RegExp(r'%% Radio\(([^,]+),\s*([^,]+),\s*([^\)]+)\)',
-            caseSensitive: false);
+        final radioExp = RegExp(
+          r'%% Radio\(([^,]+),\s*([^,]+),\s*"((?:[^"\\]|\\.)*)"\)',
+          caseSensitive: false,
+        );
         final radioMatch = radioExp.firstMatch(command);
 
         if (radioMatch != null) {
           final name = radioMatch.group(1)!.trim();
           final value = radioMatch.group(2)!.trim();
-          final label = radioMatch.group(3)!.trim();
+
+          // Process the label parameter.
+
+          String label = radioMatch.group(3)!;
+          label = label.replaceAll(r'\"', '"');
+          label = label.replaceAll('\n', ' ');
+          label = label.trim();
 
           // If starting a new radio group or the group name has changed.
 
@@ -547,14 +555,21 @@ class CommandParser {
         }
 
         final checkboxExp = RegExp(
-            r'%% Checkbox\(([^,]+),\s*([^,]+),\s*([^\)]+)\)',
-            caseSensitive: false);
+          r'%% Checkbox\(([^,]+),\s*([^,]+),\s*"((?:[^"\\]|\\.)*)"\)',
+          caseSensitive: false,
+        );
         final checkboxMatch = checkboxExp.firstMatch(command);
 
         if (checkboxMatch != null) {
           final name = checkboxMatch.group(1)!.trim();
           final value = checkboxMatch.group(2)!.trim();
-          final label = checkboxMatch.group(3)!.trim();
+
+          // Process the label parameter.
+
+          String label = checkboxMatch.group(3)!;
+          label = label.replaceAll(r'\"', '"');
+          label = label.replaceAll('\n', ' ');
+          label = label.trim();
 
           // If starting a new checkbox group or the group name has changed.
 

--- a/lib/src/widgets/checkbox_group.dart
+++ b/lib/src/widgets/checkbox_group.dart
@@ -102,12 +102,12 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Add a half-height blank line before the first option.
+            // Add a half line height of blank line before the first option.
 
             SizedBox(height: halfLineHeight),
 
-            // Use the spread operator to insert the options list into the list
-            // of child components.
+            // Insert the options list into the children list using spread
+            // operator.
 
             ...widget.options.map((option) {
               bool isChecked = _selectedValues.contains(option['value']!);
@@ -116,6 +116,9 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
                   _onChanged(option['value']!, !isChecked);
                 },
                 child: Row(
+                  // Align the checkbox and text vertically at the top.
+
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Checkbox(
                       value: isChecked,
@@ -124,8 +127,14 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
                       },
                     ),
                     Expanded(
-                      child: Text(
-                        option['label']!,
+                      child: Padding(
+                        // Add a small padding above the text to align with
+                        // checkbox.
+
+                        padding: const EdgeInsets.only(top: 6.0),
+                        child: Text(
+                          option['label']!,
+                        ),
                       ),
                     ),
                   ],
@@ -133,7 +142,7 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
               );
             }).toList(),
 
-            // Add a half-height blank line after the last option.
+            // Add a half line height of blank line after the last option.
 
             SizedBox(height: halfLineHeight),
           ],

--- a/lib/src/widgets/checkbox_group.dart
+++ b/lib/src/widgets/checkbox_group.dart
@@ -83,35 +83,60 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
 
   @override
   Widget build(BuildContext context) {
+    // Get the font size of the text, default value is 14.0.
+
+    double fontSize = Theme.of(context).textTheme.bodyLarge?.fontSize ?? 14.0;
+
+    // Assume the line height is 1.2 times the font size.
+
+    double lineHeight = fontSize * 1.2;
+
+    // Calculate half line height.
+
+    double halfLineHeight = lineHeight / 2;
+
     return Center(
       child: ConstrainedBox(
         constraints:
             BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: widget.options.map((option) {
-            bool isChecked = _selectedValues.contains(option['value']!);
-            return GestureDetector(
-              onTap: () {
-                _onChanged(option['value']!, !isChecked);
-              },
-              child: Row(
-                children: [
-                  Checkbox(
-                    value: isChecked,
-                    onChanged: (bool? newValue) {
-                      _onChanged(option['value']!, newValue);
-                    },
-                  ),
-                  Expanded(
-                    child: Text(
-                      option['label']!,
+          children: [
+            // Add a half-height blank line before the first option.
+
+            SizedBox(height: halfLineHeight),
+
+            // Use the spread operator to insert the options list into the list
+            // of child components.
+
+            ...widget.options.map((option) {
+              bool isChecked = _selectedValues.contains(option['value']!);
+              return GestureDetector(
+                onTap: () {
+                  _onChanged(option['value']!, !isChecked);
+                },
+                child: Row(
+                  children: [
+                    Checkbox(
+                      value: isChecked,
+                      onChanged: (bool? newValue) {
+                        _onChanged(option['value']!, newValue);
+                      },
                     ),
-                  ),
-                ],
-              ),
-            );
-          }).toList(),
+                    Expanded(
+                      child: Text(
+                        option['label']!,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+
+            // Add a half-height blank line after the last option.
+
+            SizedBox(height: halfLineHeight),
+          ],
         ),
       ),
     );

--- a/lib/src/widgets/checkbox_group.dart
+++ b/lib/src/widgets/checkbox_group.dart
@@ -31,7 +31,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
-    show contentWidthFactor;
+    show contentWidthFactor, screenWidth;
 
 class CheckboxGroup extends StatefulWidget {
   final String name;
@@ -84,8 +84,9 @@ class _CheckboxGroupState extends State<CheckboxGroup> {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: FractionallySizedBox(
-        widthFactor: contentWidthFactor,
+      child: ConstrainedBox(
+        constraints:
+            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: widget.options.map((option) {

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -49,33 +49,58 @@ class RadioGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Get the font size of the text, default value is 14.0.
+
+    double fontSize = Theme.of(context).textTheme.bodyLarge?.fontSize ?? 14.0;
+
+    // Assume the line height is 1.2 times the font size.
+
+    double lineHeight = fontSize * 1.2;
+
+    // Half line height.
+
+    double halfLineHeight = lineHeight / 2;
+
     return Center(
       child: ConstrainedBox(
         constraints:
-            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
+        BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: options.map((option) {
-            return InkWell(
-              onTap: () {
-                onChanged(option['value']);
-              },
-              child: Row(
-                children: [
-                  Radio<String>(
-                    value: option['value']!,
-                    groupValue: selectedValue,
-                    onChanged: onChanged,
-                  ),
-                  Expanded(
-                    child: Text(
-                      option['label']!,
+          children: [
+            // Add a half-height blank line before the first option.
+
+            SizedBox(height: halfLineHeight),
+
+            // Use the spread operator to insert the options list into the list
+            // of child components.
+
+            ...options.map((option) {
+              return InkWell(
+                onTap: () {
+                  onChanged(option['value']);
+                },
+                child: Row(
+                  children: [
+                    Radio<String>(
+                      value: option['value']!,
+                      groupValue: selectedValue,
+                      onChanged: onChanged,
                     ),
-                  ),
-                ],
-              ),
-            );
-          }).toList(),
+                    Expanded(
+                      child: Text(
+                        option['label']!,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+
+            // Add a half-height blank line after the last option.
+
+            SizedBox(height: halfLineHeight),
+          ],
         ),
       ),
     );

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -64,16 +64,16 @@ class RadioGroup extends StatelessWidget {
     return Center(
       child: ConstrainedBox(
         constraints:
-        BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
+            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Add a half-height blank line before the first option.
+            // Add a half line height of blank line before the first option.
 
             SizedBox(height: halfLineHeight),
 
-            // Use the spread operator to insert the options list into the list
-            // of child components.
+            // Use the spread operator to insert the options list into the
+            // children list.
 
             ...options.map((option) {
               return InkWell(
@@ -81,6 +81,9 @@ class RadioGroup extends StatelessWidget {
                   onChanged(option['value']);
                 },
                 child: Row(
+                  // Align the radio button and text vertically at the top.
+
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Radio<String>(
                       value: option['value']!,
@@ -88,8 +91,13 @@ class RadioGroup extends StatelessWidget {
                       onChanged: onChanged,
                     ),
                     Expanded(
-                      child: Text(
-                        option['label']!,
+                      child: Padding(
+                        // Add a small padding above the text.
+
+                        padding: const EdgeInsets.only(top: 6.0),
+                        child: Text(
+                          option['label']!,
+                        ),
                       ),
                     ),
                   ],
@@ -97,7 +105,7 @@ class RadioGroup extends StatelessWidget {
               );
             }).toList(),
 
-            // Add a half-height blank line after the last option.
+            // Add a half line height of blank line after the last option.
 
             SizedBox(height: halfLineHeight),
           ],

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -31,7 +31,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
-    show contentWidthFactor;
+    show contentWidthFactor, screenWidth;
 
 class RadioGroup extends StatelessWidget {
   final String name;
@@ -50,8 +50,9 @@ class RadioGroup extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: FractionallySizedBox(
-        widthFactor: contentWidthFactor,
+      child: ConstrainedBox(
+        constraints:
+            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: options.map((option) {

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -64,7 +64,7 @@ class RadioGroup extends StatelessWidget {
     return Center(
       child: ConstrainedBox(
         constraints:
-        BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
+            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Adjusted the maximum string length of the label for radio buttons and checkboxes that can be displayed in a single line.

- Link to associated issue: #43

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev