### PR TITLE
Tony/46_allow_extra_space

### DIFF
--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -33,10 +33,15 @@ Please select an option from the dropdown menu.
 1. This is Question 1. The following four options belong to the same group.
    Only one option can be selected.
 
-%% Radio(Question 1,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
-%% Radio(Question 1,2,Option 2)
-%% Radio(Question 1,3,Option 3)
-%% Radio(Question 1,4,Option 4)
+%% Radio(Question 1,1,"Option 1 This is a long option that may wrap to the next
+line if it needs to. When wrapping it does so indented to align the paragraph.
+This example also demonstrates the use of escape characters, such as \".")
+
+%% Radio(Question 1,2,"Option 2")
+
+%% Radio(Question 1,3,"Option 3")
+
+%% Radio(Question 1,4,"Option 4")
 
 %% EmptyLine
 
@@ -45,33 +50,49 @@ Please select an option from the dropdown menu.
    selections for these two groups are independent and will not affect each 
    other. 
 
-%% Radio(Question 2,1,Option 1)
-%% Radio(Question 2,2,Option 2)
-%% Radio(Question 2,3,Option 3)
-%% Radio(Question 2,4,Option 4)
+%% Radio(Question 2,1,"Option 1")
+
+%% Radio(Question 2,2,"Option 2")
+
+%% Radio(Question 2,3,"Option 3")
+
+%% Radio(Question 2,4,"Option 4")
 
 %% EmptyLine
 
 3. The following are two groups of checkboxes. This is Question 3. Multiple 
    options can be selected.
 
-%% Checkbox(Question 3,1,Option 1 This is a long option that may wrap to the next line if it needs to. When wrapping it does so indented to align the paragraph.)
-%% Checkbox(Question 3,2,Option 2)
-%% Checkbox(Question 3,3,Option 3)
-%% Checkbox(Question 3,4,Option 4)
-%% Checkbox(Question 3,5,Option 5)
-%% Checkbox(Question 3,6,Option 6)
+%% Checkbox(Question 3,1,"Option 1 This is a long option that may wrap to the
+next line if it needs to. When wrapping it does so indented to align the
+paragraph. This example also demonstrates the use of escape characters, such
+as \".")
+
+%% Checkbox(Question 3,2,"Option 2")
+
+%% Checkbox(Question 3,3,"Option 3")
+
+%% Checkbox(Question 3,4,"Option 4")
+
+%% Checkbox(Question 3,5,"Option 5")
+
+%% Checkbox(Question 3,6,"Option 6")
 
 %% EmptyLine
 
 4. This is Question 4. Multiple options can be selected as well.
 
-%% Checkbox(Question 4,1,Option 1)
-%% Checkbox(Question 4,2,Option 2)
-%% Checkbox(Question 4,3,Option 3)
-%% Checkbox(Question 4,4,Option 4)
-%% Checkbox(Question 4,5,Option 5)
-%% Checkbox(Question 4,6,Option 6)
+%% Checkbox(Question 4,1,"Option 1")
+
+%% Checkbox(Question 4,2,"Option 2")
+
+%% Checkbox(Question 4,3,"Option 3")
+
+%% Checkbox(Question 4,4,"Option 4")
+
+%% Checkbox(Question 4,5,"Option 5")
+
+%% Checkbox(Question 4,6,"Option 6")
 
 %% EmptyLine
 

--- a/lib/src/utils/command_parser.dart
+++ b/lib/src/utils/command_parser.dart
@@ -476,14 +476,22 @@ class CommandParser {
           currentCheckboxOptions = [];
         }
 
-        final radioExp = RegExp(r'%% Radio\(([^,]+),\s*([^,]+),\s*([^\)]+)\)',
-            caseSensitive: false);
+        final radioExp = RegExp(
+          r'%% Radio\(([^,]+),\s*([^,]+),\s*"((?:[^"\\]|\\.)*)"\)',
+          caseSensitive: false,
+        );
         final radioMatch = radioExp.firstMatch(command);
 
         if (radioMatch != null) {
           final name = radioMatch.group(1)!.trim();
           final value = radioMatch.group(2)!.trim();
-          final label = radioMatch.group(3)!.trim();
+
+          // Process the label parameter.
+
+          String label = radioMatch.group(3)!;
+          label = label.replaceAll(r'\"', '"');
+          label = label.replaceAll('\n', ' ');
+          label = label.trim();
 
           // If starting a new radio group or the group name has changed.
 
@@ -547,14 +555,21 @@ class CommandParser {
         }
 
         final checkboxExp = RegExp(
-            r'%% Checkbox\(([^,]+),\s*([^,]+),\s*([^\)]+)\)',
-            caseSensitive: false);
+          r'%% Checkbox\(([^,]+),\s*([^,]+),\s*"((?:[^"\\]|\\.)*)"\)',
+          caseSensitive: false,
+        );
         final checkboxMatch = checkboxExp.firstMatch(command);
 
         if (checkboxMatch != null) {
           final name = checkboxMatch.group(1)!.trim();
           final value = checkboxMatch.group(2)!.trim();
-          final label = checkboxMatch.group(3)!.trim();
+
+          // Process the label parameter.
+
+          String label = checkboxMatch.group(3)!;
+          label = label.replaceAll(r'\"', '"');
+          label = label.replaceAll('\n', ' ');
+          label = label.trim();
 
           // If starting a new checkbox group or the group name has changed.
 

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -64,7 +64,7 @@ class RadioGroup extends StatelessWidget {
     return Center(
       child: ConstrainedBox(
         constraints:
-        BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
+            BoxConstraints(maxWidth: screenWidth(context) * contentWidthFactor),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Used double quotes as string identifiers in `radio` and `checkbox` commands.
- Made label text comply with Markdown syntax, and ignore single line breaks in the text.
- Added blank lines in the Markdown file.

- Link to associated issue: #46

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev