### PR TITLE
Tony/58_auto_reload_md_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,17 @@ markdown pages.
 
 In the example code of this package, users can customise the paths for 
 markdown files and media files by modifying the `config.json` file. The
-`config.json` file is located in the `Debug` and `Release` folders, at the same
-level as the app folder. Additionally, the `example` directory provides an
-`assets` folder, which contains sample markdown files and media files.
+`config.json` file is located in the `assets` folder. The location of the 
+`assets` folder may be different on different platform:
+
+On macOS, it is at `riopod/build/macos/Build/Products/Debug/riopod.app/Contents
+/Frameworks/App.framework/Versions/A/Resources/flutter_assets/assets`.
+
+On Windows, it is at `riopod\build\windows\x64\runner\Debug\data\flutter_assets
+\assets`.
+
+On Linux, it is at `riopod/build/linux/x64/debug/bundle/data/flutter_assets/
+assets`.
 
 ## Survey Menu
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ syntax, making it suitable for use in surveys and similar scenarios.
 The following is the syntax to generate interactive surveys in
 markdown pages.
 
-In the example code of this package, the path of the sample markdown file is
-`example/assets/sample_markdown.md`. This path can be set in the code to load
-the markdown file at runtime.
+In the example code of this package, users can customise the paths for 
+markdown files and media files by modifying the `config.json` file. The
+`config.json` file is located in the `Debug` and `Release` folders, at the same
+level as the app folder. Additionally, the `example` directory provides an
+`assets` folder, which contains sample markdown files and media files.
 
 ## Survey Menu
 

--- a/example/assets/config.json
+++ b/example/assets/config.json
@@ -1,0 +1,10 @@
+{
+  "markdown": {
+    "path": "sample_markdown.md",
+    "type": "local/http"
+  },
+  "media": {
+    "path": "media",
+    "type": "local/http"
+  }
+}

--- a/example/assets/config.json
+++ b/example/assets/config.json
@@ -1,10 +1,10 @@
 {
   "markdown": {
     "path": "sample_markdown.md",
-    "type": "local/http"
+    "type": "local"
   },
   "media": {
     "path": "media",
-    "type": "local/http"
+    "type": "local"
   }
 }

--- a/example/assets/sample_markdown.md
+++ b/example/assets/sample_markdown.md
@@ -46,7 +46,7 @@ label, such as \( and \).")
 
 %% EmptyLine
 
-1. This is Question 2. Only one option can be selected. The following four 
+2. This is Question 2. Only one option can be selected. The following four 
    options belong to a different group from Question 1, and the user's 
    selections for these two groups are independent and will not affect each 
    other. 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 /// An example of loading a markdown with 4 surveys and rendering them.
 ///
-// Time-stamp: <Sunday 2025-01-14 10:00:31 +1100 Graham Williams>
+// Time-stamp: <Tuesday 2025-01-14 10:00:31 +1100 Tony Chen>
 ///
 /// Copyright (C) 2024, Software Innovation Institute, ANU.
 ///
@@ -38,6 +38,7 @@ import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:markdown_widget_builder/markdown_widget_builder.dart';
+import 'package:markdown_widget_builder/src/constants/pkg.dart' as pkg;
 
 /// A simple class to represent the structure:
 /// { "path": "some/path", "type": "local/pod" }
@@ -229,6 +230,10 @@ class _MarkdownExamplePageState extends State<MarkdownExamplePage> {
         // Resolve final absolute path for media folder (or file).
 
         final mediaFilePath = _resolvePath(config.media.path);
+
+        // Update the global mediaPath in pkg.dart with the resolved media path.
+
+        pkg.setMediaPath(mediaFilePath);
 
         // Load markdown and set up watcher.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,18 +30,17 @@
 
 library;
 
-import 'dart:io';
-import 'dart:convert';
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:markdown_widget_builder/markdown_widget_builder.dart'
+    show MarkdownWidgetBuilder, setMarkdownMediaPath;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
-
-import 'package:markdown_widget_builder/markdown_widget_builder.dart'
-    show MarkdownWidgetBuilder, setMarkdownMediaPath;
 
 /// A simple class to represent the structure:
 /// { "path": "file path", "type": "local/http, pod" }
@@ -188,8 +187,10 @@ class _MarkdownExamplePageState extends State<MarkdownExamplePage> {
 
       // Watch for changes.
 
-      _fileWatchSub = file.watch().listen((event) async {
-        if (event.type == FileSystemEvent.modify) {
+      final parentDirectory = Directory(p.dirname(interpretedPath));
+      _fileWatchSub = parentDirectory.watch().listen((event) async {
+        if (event.type == FileSystemEvent.modify &&
+            event.path == interpretedPath) {
           if (await file.exists()) {
             final updated = await file.readAsString();
             setState(() => _markdownContent = updated);

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<!-- <key>com.apple.security.app-sandbox</key>
+	<true/> -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+    <!-- <key>com.apple.security.app-sandbox</key>
+    <true/> -->
     <key>com.apple.security.network.client</key>
     <true/>
 </dict>

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A sample app for markdown widgets."
 publish_to: 'none'
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: '>=3.4.3 <4.0.0'
@@ -26,7 +26,9 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-#dependency_overrides:
+dependency_overrides:
+  flutter_secure_storage_linux: ^2.0.1
+  flutter_secure_storage_platform_interface: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,6 +28,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-  assets:
-    - assets/sample_markdown.md
-    - assets/media/

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  path: ^1.9.0
+  path_provider: ^2.1.5
   markdown_widget_builder: # ^0.0.3
     path: ../
 
@@ -28,3 +30,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/config.json

--- a/lib/markdown_widget_builder.dart
+++ b/lib/markdown_widget_builder.dart
@@ -33,3 +33,11 @@ library markdown_widget_builder;
 // Markdown widget builder.
 
 export 'src/widgets/markdown_widget_builder.dart' show MarkdownWidgetBuilder;
+
+import 'src/constants/pkg.dart' as pkg;
+
+/// Public method that sets the media path inside the package.
+
+void setMarkdownMediaPath(String newMediaPath) {
+  pkg.setMediaPath(newMediaPath);
+}

--- a/lib/markdown_widget_builder.dart
+++ b/lib/markdown_widget_builder.dart
@@ -32,12 +32,5 @@ library markdown_widget_builder;
 
 // Markdown widget builder.
 
-export 'src/widgets/markdown_widget_builder.dart' show MarkdownWidgetBuilder;
-
-import 'src/constants/pkg.dart' as pkg;
-
-/// Public method that sets the media path inside the package.
-
-void setMarkdownMediaPath(String newMediaPath) {
-  pkg.setMediaPath(newMediaPath);
-}
+export 'src/widgets/markdown_widget_builder.dart'
+    show MarkdownWidgetBuilder, setMarkdownMediaPath;

--- a/lib/src/constants/pkg.dart
+++ b/lib/src/constants/pkg.dart
@@ -37,12 +37,29 @@ const String applicationVersion = '0.1.0';
 const String applicationRepo =
     'https://github.com/anusii/markdown_widget_builder';
 const String siiUrl = 'https://sii.anu.edu.au';
-const String assetsPath = 'assets';
-const String mediaPath = 'assets/media';
-const String surveyAsset = 'assets/surveys.md';
 
 const String defaultFileName = 'survey.json';
 const String defaultButtonText = 'Save';
+
+String _assetsPath = 'assets';
+String _mediaPath = 'assets/media';
+String _mdPath = 'assets/surveys.md';
+
+String get assetsPath => _assetsPath;
+String get mediaPath => _mediaPath;
+String get mdPath => _mdPath;
+
+void setAssetsPath(String newAssetsPath) {
+  _assetsPath = newAssetsPath;
+}
+
+void setMediaPath(String newMediaPath) {
+  _mediaPath = newMediaPath;
+}
+
+void setMdPath(String newMdPath) {
+  _mdPath = newMdPath;
+}
 
 double screenWidth(BuildContext context) => MediaQuery.of(context).size.width;
 double screenHeight(BuildContext context) => MediaQuery.of(context).size.height;

--- a/lib/src/widgets/audio_widget.dart
+++ b/lib/src/widgets/audio_widget.dart
@@ -35,7 +35,7 @@ import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
-    show contentWidthFactor;
+    show contentWidthFactor, mediaPath;
 
 class AudioWidget extends StatefulWidget {
   final String filename;
@@ -67,11 +67,23 @@ class _AudioWidgetState extends State<AudioWidget> {
   }
 
   void _initAudioPlayer() async {
-    final String audioAssetPath = 'media/${widget.filename}';
+    // Build the raw path from mediaPath + filename.
 
-    // Load the audio file.
+    final String rawLocalPath = '$mediaPath/${widget.filename}';
 
-    await _player.setSource(AssetSource(audioAssetPath));
+    // If rawLocalPath has 'file://', parse it to pure local path;
+    // otherwise use rawLocalPath as is.
+
+    String localPath;
+    if (rawLocalPath.startsWith('file://')) {
+      localPath = Uri.parse(rawLocalPath).toFilePath();
+    } else {
+      localPath = rawLocalPath;
+    }
+
+    await _player.setSource(
+      DeviceFileSource(localPath),
+    );
 
     // Listen for audio duration.
 

--- a/lib/src/widgets/image_widget.dart
+++ b/lib/src/widgets/image_widget.dart
@@ -28,6 +28,8 @@
 ///
 /// Authors: Tony Chen
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
@@ -47,13 +49,24 @@ class ImageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String imgPath = '$mediaPath/$filename';
+    // Build the local raw path by concatenating mediaPath + filename.
+
+    final String rawLocalPath = '$mediaPath/$filename';
+
+    // Convert it to an OS path (without file://).
+
+    String localPath;
+    if (rawLocalPath.startsWith('file://')) {
+      localPath = Uri.parse(rawLocalPath).toFilePath();
+    } else {
+      localPath = rawLocalPath;
+    }
 
     return Center(
       child: FractionallySizedBox(
         widthFactor: contentWidthFactor,
-        child: Image.asset(
-          imgPath,
+        child: Image.file(
+          File(localPath),
           width: width,
           height: height,
           fit: BoxFit.contain,

--- a/lib/src/widgets/markdown_widget_builder.dart
+++ b/lib/src/widgets/markdown_widget_builder.dart
@@ -35,6 +35,13 @@ import 'package:media_kit/media_kit.dart';
 
 import 'package:markdown_widget_builder/src/utils/command_parser.dart';
 import 'package:markdown_widget_builder/src/widgets/input_field.dart';
+import 'package:markdown_widget_builder/src/constants/pkg.dart' as pkg;
+
+/// Sets the media path inside the package.
+
+void setMarkdownMediaPath(String newMediaPath) {
+  pkg.setMediaPath(newMediaPath);
+}
 
 /// The MarkdownWidgetBuilder is a stateful widget that takes in markdown-like
 /// content and a title. It uses the CommandParser to interpret custom commands

--- a/lib/src/widgets/video_widget.dart
+++ b/lib/src/widgets/video_widget.dart
@@ -63,7 +63,16 @@ class _VideoWidgetState extends State<VideoWidget> {
   }
 
   Future<void> _initializeVideo() async {
-    final String videoAssetPath = '$mediaPath/${widget.filename}';
+    // Build the raw local path by concatenating mediaPath + filename.
+
+    final String rawLocalPath = '$mediaPath/${widget.filename}';
+
+    // Convert to a 'file://' URI so media_kit treats it as a local file,
+    // not a Flutter asset.
+
+    final String fileUri = rawLocalPath.startsWith('file://')
+        ? rawLocalPath
+        : 'file://$rawLocalPath';
 
     // Initialise the player.
 
@@ -72,7 +81,7 @@ class _VideoWidgetState extends State<VideoWidget> {
 
     // Open the video.
 
-    await _player.open(Media('asset://$videoAssetPath'), play: false);
+    await _player.open(Media(fileUri), play: false);
 
     // Set video initialised.
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Allow researchers to specify the location of the survey markdown file and media files from a local path.
- Automatically load the new file after the markdown file is modified.
- Link to associated issue: #58, https://github.com/anusii/riopod/issues/52

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev