### PR TITLE
Tony/181 import order lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,26 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true
+    prefer_single_quotes: true
+
+analyzer:
+  plugins:
+    - custom_lint
+
+custom_lint:
+  rules:
+    - import_order_lint
+  options:
+    import_order_lint:
+      project_name: markdown_widget_builder

--- a/lib/markdown_widget_builder.dart
+++ b/lib/markdown_widget_builder.dart
@@ -28,7 +28,7 @@
 ///
 /// Authors: Tony Chen
 
-library markdown_widget_builder;
+library;
 
 export 'src/widgets/markdown_widget_builder.dart'
     show MarkdownWidgetBuilder, setMarkdownMediaPath;

--- a/lib/src/utils/command_parser.dart
+++ b/lib/src/utils/command_parser.dart
@@ -31,6 +31,7 @@
 library;
 
 import 'package:flutter/material.dart';
+
 import 'package:markdown_widget_builder/src/utils/helpers.dart';
 import 'package:markdown_widget_builder/src/widgets/button_widget.dart';
 import 'package:markdown_widget_builder/src/widgets/markdown_text.dart';

--- a/lib/src/utils/file_ops.dart
+++ b/lib/src/utils/file_ops.dart
@@ -1,4 +1,4 @@
-library file_ops;
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/utils/helpers.dart
+++ b/lib/src/utils/helpers.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 

--- a/lib/src/utils/justify_text.dart
+++ b/lib/src/utils/justify_text.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -59,7 +60,7 @@ List<TextSpan> justifyText(String text, TextStyle style, double maxWidth) {
     }
 
     if (units.length <= 1) {
-      justifiedSpans.add(TextSpan(text: '$trimmedLine', style: blackTextStyle));
+      justifiedSpans.add(TextSpan(text: trimmedLine, style: blackTextStyle));
       continue;
     }
 
@@ -82,7 +83,7 @@ List<TextSpan> justifyText(String text, TextStyle style, double maxWidth) {
     if (extraSpace <= 0) {
       // If there's no extra space, no need to adjust.
 
-      justifiedSpans.add(TextSpan(text: '$trimmedLine', style: blackTextStyle));
+      justifiedSpans.add(TextSpan(text: trimmedLine, style: blackTextStyle));
       continue;
     }
 

--- a/lib/src/utils/parse_time_string.dart
+++ b/lib/src/utils/parse_time_string.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 /// Parse the time string and return the total number of seconds.
 /// Supported formats include:

--- a/lib/src/widgets/audio_widget.dart
+++ b/lib/src/widgets/audio_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'dart:async';
 
@@ -40,7 +41,7 @@ import 'package:markdown_widget_builder/src/constants/pkg.dart'
 class AudioWidget extends StatefulWidget {
   final String filename;
 
-  const AudioWidget({Key? key, required this.filename}) : super(key: key);
+  const AudioWidget({super.key, required this.filename});
 
   @override
   _AudioWidgetState createState() => _AudioWidgetState();

--- a/lib/src/widgets/button_widget.dart
+++ b/lib/src/widgets/button_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'dart:async';
 import 'dart:convert';
@@ -47,13 +48,13 @@ class ButtonWidget extends StatefulWidget {
   final Map<String, dynamic> state;
   final String surveyTitle;
 
-  ButtonWidget({
-    Key? key,
+  const ButtonWidget({
+    super.key,
     required this.command,
     required this.requiredWidgets,
     required this.state,
     required this.surveyTitle,
-  }) : super(key: key);
+  });
 
   @override
   _ButtonWidgetState createState() => _ButtonWidgetState();
@@ -105,30 +106,30 @@ class _ButtonWidgetState extends State<ButtonWidget> {
 
     final Map<String, dynamic> responses = {};
 
-    final _inputValues = widget.state['_inputValues'] as Map<String, String>;
-    final _sliderValues = widget.state['_sliderValues'] as Map<String, double>;
-    final _radioValues = widget.state['_radioValues'] as Map<String, String?>;
-    final _checkboxValues =
+    final inputValues = widget.state['_inputValues'] as Map<String, String>;
+    final sliderValues = widget.state['_sliderValues'] as Map<String, double>;
+    final radioValues = widget.state['_radioValues'] as Map<String, String?>;
+    final checkboxValues =
         widget.state['_checkboxValues'] as Map<String, Set<String>>;
-    final _dateValues = widget.state['_dateValues'] as Map<String, DateTime?>;
-    final _dropdownValues =
+    final dateValues = widget.state['_dateValues'] as Map<String, DateTime?>;
+    final dropdownValues =
         widget.state['_dropdownValues'] as Map<String, String?>;
 
     // Add slider values.
 
-    _sliderValues.forEach((key, value) {
+    sliderValues.forEach((key, value) {
       responses[key] = value;
     });
 
     // Add radio values.
 
-    _radioValues.forEach((key, value) {
+    radioValues.forEach((key, value) {
       responses[key] = value;
     });
 
     // Add checkbox values.
 
-    _checkboxValues.forEach((key, value) {
+    checkboxValues.forEach((key, value) {
       // Convert Set to List.
 
       responses[key] = value.toList();
@@ -136,7 +137,7 @@ class _ButtonWidgetState extends State<ButtonWidget> {
 
     // Add date values.
 
-    _dateValues.forEach((key, value) {
+    dateValues.forEach((key, value) {
       if (value != null) {
         responses[key] =
             '${value.year}-${value.month.toString().padLeft(2, '0')}-'
@@ -148,13 +149,13 @@ class _ButtonWidgetState extends State<ButtonWidget> {
 
     // Add dropdown values.
 
-    _dropdownValues.forEach((key, value) {
+    dropdownValues.forEach((key, value) {
       responses[key] = value;
     });
 
     // Add text input values.
 
-    _inputValues.forEach((key, value) {
+    inputValues.forEach((key, value) {
       responses[key] = value;
     });
 
@@ -307,7 +308,7 @@ class _ButtonWidgetState extends State<ButtonWidget> {
     }
   }
 
-  JsonEncoder encoder = new JsonEncoder.withIndent('  ');
+  JsonEncoder encoder = JsonEncoder.withIndent('  ');
 
   Future<void> _saveDataLocally(Map<String, dynamic> data) async {
     debugPrint('Collected Data:');

--- a/lib/src/widgets/calendar_field.dart
+++ b/lib/src/widgets/calendar_field.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -39,11 +40,11 @@ class CalendarField extends StatefulWidget {
   final ValueChanged<DateTime?> onDateSelected;
 
   const CalendarField({
-    Key? key,
+    super.key,
     required this.name,
     this.initialDate,
     required this.onDateSelected,
-  }) : super(key: key);
+  });
 
   @override
   _CalendarFieldState createState() => _CalendarFieldState();

--- a/lib/src/widgets/checkbox_group.dart
+++ b/lib/src/widgets/checkbox_group.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -42,13 +43,13 @@ class CheckboxGroup extends StatefulWidget {
       onChanged;
 
   const CheckboxGroup({
-    Key? key,
+    super.key,
     required this.name,
     required this.options,
     required this.selectedValues,
     required this.onChanged,
     this.isRequired = false,
-  }) : super(key: key);
+  });
 
   @override
   _CheckboxGroupState createState() => _CheckboxGroupState();

--- a/lib/src/widgets/description_box.dart
+++ b/lib/src/widgets/description_box.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -39,7 +40,7 @@ import 'package:markdown_widget_builder/src/constants/pkg.dart'
 class DescriptionBox extends StatelessWidget {
   final String content;
 
-  const DescriptionBox({Key? key, required this.content}) : super(key: key);
+  const DescriptionBox({super.key, required this.content});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/dropdown_widget.dart
+++ b/lib/src/widgets/dropdown_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -40,12 +41,12 @@ class DropdownWidget extends StatefulWidget {
   final ValueChanged<String?> onChanged;
 
   const DropdownWidget({
-    Key? key,
+    super.key,
     required this.name,
     required this.options,
     this.value,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   _DropdownWidgetState createState() => _DropdownWidgetState();

--- a/lib/src/widgets/image_widget.dart
+++ b/lib/src/widgets/image_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'dart:io';
 
@@ -41,11 +42,11 @@ class ImageWidget extends StatelessWidget {
   final double? height;
 
   const ImageWidget({
-    Key? key,
+    super.key,
     required this.filename,
     this.width,
     this.height,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/input_field.dart
+++ b/lib/src/widgets/input_field.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -40,12 +41,12 @@ class InputField extends StatefulWidget {
   final ValueChanged<String> onChanged;
 
   const InputField({
-    Key? key,
+    super.key,
     required this.name,
     this.initialValue,
     this.isMultiLine = false,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   InputFieldState createState() => InputFieldState();

--- a/lib/src/widgets/markdown_text.dart
+++ b/lib/src/widgets/markdown_text.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -39,7 +40,7 @@ import 'package:markdown_widget_builder/src/constants/pkg.dart'
 class MarkdownText extends StatelessWidget {
   final String data;
 
-  const MarkdownText({Key? key, required this.data}) : super(key: key);
+  const MarkdownText({super.key, required this.data});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/markdown_widget_builder.dart
+++ b/lib/src/widgets/markdown_widget_builder.dart
@@ -27,15 +27,16 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
 import 'package:audioplayers/audioplayers.dart';
 import 'package:media_kit/media_kit.dart';
 
+import 'package:markdown_widget_builder/src/constants/pkg.dart' as pkg;
 import 'package:markdown_widget_builder/src/utils/command_parser.dart';
 import 'package:markdown_widget_builder/src/widgets/input_field.dart';
-import 'package:markdown_widget_builder/src/constants/pkg.dart' as pkg;
 
 /// Sets the media path inside the package.
 
@@ -70,12 +71,12 @@ class MarkdownWidgetBuilder extends StatefulWidget {
   final void Function(String title, String content)? onMenuItemSelected;
 
   const MarkdownWidgetBuilder({
-    Key? key,
+    super.key,
     required this.content,
     required this.title,
     this.submitUrl,
     this.onMenuItemSelected,
-  }) : super(key: key);
+  });
 
   @override
   _MarkdownWidgetBuilderState createState() => _MarkdownWidgetBuilderState();

--- a/lib/src/widgets/menu_widget.dart
+++ b/lib/src/widgets/menu_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'dart:convert';
 
@@ -41,11 +42,11 @@ class MenuWidget extends StatelessWidget {
   final void Function(String title, String content) onMenuItemSelected;
 
   const MenuWidget({
-    Key? key,
+    super.key,
     required this.menuContent,
     required this.fullContent,
     required this.onMenuItemSelected,
-  }) : super(key: key);
+  });
 
   /// Parse menu items.
 

--- a/lib/src/widgets/page_break_widget.dart
+++ b/lib/src/widgets/page_break_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -40,12 +41,12 @@ class PageBreakWidget extends StatelessWidget {
   final VoidCallback onPrev;
 
   const PageBreakWidget({
-    Key? key,
+    super.key,
     required this.currentPage,
     required this.totalPages,
     required this.onNext,
     required this.onPrev,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/radio_group.dart
+++ b/lib/src/widgets/radio_group.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -41,13 +42,13 @@ class RadioGroup extends StatelessWidget {
   final Function(String? value, String? hiddenContentId) onChanged;
 
   const RadioGroup({
-    Key? key,
+    super.key,
     required this.name,
     required this.options,
     this.selectedValue,
     required this.onChanged,
     this.isRequired = false,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/slider_widget.dart
+++ b/lib/src/widgets/slider_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -42,14 +43,14 @@ class SliderWidget extends StatelessWidget {
   final ValueChanged<double> onChanged;
 
   const SliderWidget({
-    Key? key,
+    super.key,
     required this.name,
     required this.value,
     required this.min,
     required this.max,
     required this.step,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/text_alignment_widget.dart
+++ b/lib/src/widgets/text_alignment_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -39,8 +40,7 @@ class TextAlignmentWidget extends StatelessWidget {
   final String content;
 
   const TextAlignmentWidget(
-      {Key? key, required this.align, required this.content})
-      : super(key: key);
+      {super.key, required this.align, required this.content});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/text_heading_widget.dart
+++ b/lib/src/widgets/text_heading_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -40,11 +41,11 @@ class TextHeadingWidget extends StatelessWidget {
   final String align;
 
   const TextHeadingWidget({
-    Key? key,
+    super.key,
     required this.level,
     required this.content,
     required this.align,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/timer_widget.dart
+++ b/lib/src/widgets/timer_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'dart:async';
 
@@ -38,7 +39,7 @@ import 'package:markdown_widget_builder/src/constants/pkg.dart'
 class TimerWidget extends StatefulWidget {
   final int totalSeconds;
 
-  const TimerWidget({Key? key, required this.totalSeconds}) : super(key: key);
+  const TimerWidget({super.key, required this.totalSeconds});
 
   @override
   _TimerWidgetState createState() => _TimerWidgetState();

--- a/lib/src/widgets/video_widget.dart
+++ b/lib/src/widgets/video_widget.dart
@@ -27,6 +27,7 @@
 // SOFTWARE.
 ///
 /// Authors: Tony Chen
+library;
 
 import 'package:flutter/material.dart';
 
@@ -39,7 +40,7 @@ import 'package:markdown_widget_builder/src/constants/pkg.dart'
 class VideoWidget extends StatefulWidget {
   final String filename;
 
-  const VideoWidget({Key? key, required this.filename}) : super(key: key);
+  const VideoWidget({super.key, required this.filename});
 
   @override
   _VideoWidgetState createState() => _VideoWidgetState();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,9 +26,11 @@ dependencies:
   path_provider: ^2.1.5
 
 dev_dependencies:
+  custom_lint: ^0.7.3
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
+  import_order_lint: ^0.1.0
 
 #   dart_code_metrics:
 #     git:

--- a/support/flutter.mk
+++ b/support/flutter.mk
@@ -31,6 +31,9 @@ flutter:
 
   docs	    Run `dart doc` to create documentation.
 
+  import_order      Run import order checking.
+  import_order_fix  Run import order fixing.
+
   fix             Run `dart fix --apply`.
   format          Run `dart format`.
   dcm             Run dart code metrics 
@@ -123,7 +126,7 @@ linux_config:
 	flutter config --enable-linux-desktop
 
 .PHONY: prep
-prep: analyze fix format dcm ignore license todo
+prep: analyze fix import_order_fix format dcm ignore license todo
 	@echo "ADVISORY: make tests docs"
 	@echo $(SEPARATOR)
 
@@ -198,7 +201,7 @@ todo:
 .PHONY: license
 license:
 	@echo "Files without a LICENSE:\n"
-	@-find lib -type f -not -name '*~' ! -exec grep -qE '^(/// .*|/// Copyright|/// Licensed)' {} \; -print | xargs printf "\t%s\n"
+	@-find lib -type f -not -name '*~' ! -exec grep -qE '^(/// .*|/// Copyright|/// Licensed)' {} \; -printf "\t%p\n"
 	@echo $(SEPARATOR)
 
 .PHONY: riverpod
@@ -326,32 +329,14 @@ endif
 publish:
 	dart pub publish
 
-### TODO THESE SHOULD BE CHECKED AND CLEANED UP
+.PHONY: import_order
+import_order:
+	@echo "Dart: CHECK IMPORT ORDER"
+	-dart run custom_lint
+	@echo $(SEPARATOR)
 
-
-.PHONY: docs
-docs::
-	rsync -avzh doc/api/ root@solidcommunity.au:/var/www/html/docs/$(APP)/
-
-.PHONY: versions
-versions:
-	perl -pi -e 's|applicationVersion = ".*";|applicationVersion = "$(VER)";|' \
-	lib/constants/app.dart
-
-.PHONY: wc
-wc: lib/*.dart
-	@cat lib/*.dart lib/*/*.dart lib/*/*/*.dart \
-	| egrep -v '^/' \
-	| egrep -v '^ *$$' \
-	| wc -l
-
-#
-# Manage the production install on the remote server.
-#
-
-.PHONY: solidcommunity
-solidcommunity:
-	rsync -avzh ./ solidcommunity.au:projects/$(APP)/ \
-	--exclude .dart_tool --exclude build --exclude ios --exclude macos \
-	--exclude linux --exclude windows --exclude android
-	ssh solidcommunity.au '(cd projects/$(APP); flutter upgrade; make prod)'
+.PHONY: import_order_fix
+import_order_fix:
+	@echo "Dart: FIX IMPORT ORDER"
+	-dart run import_order_lint:fix_imports --project-name=markdown_widget_builder -r lib
+	@echo $(SEPARATOR)

--- a/support/flutter.mk
+++ b/support/flutter.mk
@@ -126,7 +126,7 @@ linux_config:
 	flutter config --enable-linux-desktop
 
 .PHONY: prep
-prep: analyze fix import_order_fix format dcm ignore license todo
+prep: analyze fix format dcm ignore license todo
 	@echo "ADVISORY: make tests docs"
 	@echo $(SEPARATOR)
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Added `import_order` and `import_order_fix` commands to Makefile.
- Lint the code using import_order_lint.
- Added `custom_lint` package to `pubspec.yaml`.
- Corrected the branch name of `riodm` and `makedown_widget_builder`.

- Link to associated issue: [#181](https://github.com/anusii/riopod/issues/181)

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev