### PR TITLE
Tony/76 video

### DIFF
--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -3,11 +3,27 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
     <key>com.apple.security.assets.files.read-write</key>
     <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+    <key>com.apple.security.files.documents.read-write</key>
+    <true/>
+    <key>com.apple.security.files.pictures.read-write</key>
+    <true/>
+    <key>com.apple.security.files.movies.read-write</key>
+    <true/>
+    <key>com.apple.security.files.music.read-write</key>
+    <true/>
+    <key>com.apple.security.files.shared-read-write</key>
+    <true/>
+    <key>com.apple.security.files.absolute-path.read-only</key>
+    <array>
+      <string>/Users</string>
+    </array>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
     <key>com.apple.security.assets.files.read-write</key>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -3,11 +3,27 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
     <key>com.apple.security.assets.files.read-write</key>
     <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+    <key>com.apple.security.files.documents.read-write</key>
+    <true/>
+    <key>com.apple.security.files.pictures.read-write</key>
+    <true/>
+    <key>com.apple.security.files.movies.read-write</key>
+    <true/>
+    <key>com.apple.security.files.music.read-write</key>
+    <true/>
+    <key>com.apple.security.files.shared-read-write</key>
+    <true/>
+    <key>com.apple.security.files.absolute-path.read-only</key>
+    <array>
+      <string>/Users</string>
+    </array>
     <key>com.apple.security.network.client</key>
     <true/>
 </dict>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
     <key>com.apple.security.assets.files.read-write</key>

--- a/lib/src/widgets/audio_widget.dart
+++ b/lib/src/widgets/audio_widget.dart
@@ -88,10 +88,13 @@ class _AudioWidgetState extends State<AudioWidget> {
   Future<void> _initAudioPlayer() async {
     final rawLocalPath = '$mediaPath/${widget.filename}';
     final localFile = File(rawLocalPath);
-    final existsLocally = await localFile.exists();
+    final isFileExists = await localFile.exists();
+
+    final isAssetLike = rawLocalPath.startsWith('assets/') ||
+        rawLocalPath.startsWith('assets\\');
 
     String sourcePath;
-    if (existsLocally) {
+    if (isFileExists && !isAssetLike) {
       sourcePath = rawLocalPath.startsWith('file://')
           ? Uri.parse(rawLocalPath).toFilePath()
           : rawLocalPath;

--- a/lib/src/widgets/audio_widget.dart
+++ b/lib/src/widgets/audio_widget.dart
@@ -30,8 +30,12 @@
 library;
 
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:path_provider/path_provider.dart';
 
 import 'package:audioplayers/audioplayers.dart';
 
@@ -49,11 +53,14 @@ class AudioWidget extends StatefulWidget {
 
 class _AudioWidgetState extends State<AudioWidget> {
   late AudioPlayer _player;
+  String? _sourcePath;
+
   Duration? _duration;
   Duration _position = Duration.zero;
   PlayerState? _playerState;
 
-  // Declare the StreamSubscription variables.
+  bool _failedToLoad = false;
+  bool _initialized = false;
 
   late StreamSubscription<Duration> _durationSubscription;
   late StreamSubscription<Duration> _positionSubscription;
@@ -63,125 +70,138 @@ class _AudioWidgetState extends State<AudioWidget> {
   void initState() {
     super.initState();
     _player = AudioPlayer();
-
     _initAudioPlayer();
   }
 
-  void _initAudioPlayer() async {
-    // Build the path.
+  @override
+  void dispose() {
+    _durationSubscription.cancel();
+    _positionSubscription.cancel();
+    _playerStateSubscription.cancel();
+    _player.dispose();
+    super.dispose();
+  }
 
-    final String fullPath = '$mediaPath/${widget.filename}';
+  /// Loads the audio file either from a local path or from assets,
+  /// then initialises the player.
 
-    // Check if it's an asset path.
+  Future<void> _initAudioPlayer() async {
+    final rawLocalPath = '$mediaPath/${widget.filename}';
+    final localFile = File(rawLocalPath);
+    final existsLocally = await localFile.exists();
 
-    if (mediaPath.startsWith('assets/')) {
-      final relativeAsset = fullPath.replaceFirst('assets/', '');
-      await _player.setSource(AssetSource(relativeAsset));
+    String sourcePath;
+    if (existsLocally) {
+      sourcePath = rawLocalPath.startsWith('file://')
+          ? Uri.parse(rawLocalPath).toFilePath()
+          : rawLocalPath;
     } else {
-      // local file approach.
+      try {
+        final ByteData data = await rootBundle.load(rawLocalPath);
+        final Uint8List bytes = data.buffer.asUint8List();
 
-      String localPath = fullPath;
-      if (fullPath.startsWith('file://')) {
-        localPath = Uri.parse(fullPath).toFilePath();
+        final tempDir = await getTemporaryDirectory();
+        final fileNameOnly = widget.filename.split('/').last;
+        final tempPath = '${tempDir.path}/$fileNameOnly';
+
+        final tempFile = File(tempPath);
+        await tempFile.writeAsBytes(bytes);
+
+        sourcePath = tempFile.path;
+      } catch (e) {
+        _failedToLoad = true;
+        setState(() {});
+        return;
       }
-      await _player.setSource(DeviceFileSource(localPath));
     }
 
-    // Listen for audio duration.
+    _sourcePath = sourcePath;
+
+    try {
+      await _player.setSource(DeviceFileSource(_sourcePath!));
+    } catch (e) {
+      _failedToLoad = true;
+      setState(() {});
+      return;
+    }
 
     _durationSubscription = _player.onDurationChanged.listen((d) {
       if (mounted) setState(() => _duration = d);
     });
 
-    // Listen for audio position.
-
     _positionSubscription = _player.onPositionChanged.listen((p) {
       if (mounted) setState(() => _position = p);
     });
 
-    // Listen for player state.
-
     _playerStateSubscription = _player.onPlayerStateChanged.listen((s) {
       if (mounted) setState(() => _playerState = s);
+    });
+
+    setState(() {
+      _initialized = true;
     });
   }
 
   @override
-  void dispose() {
-    // Cancel the subscriptions.
-
-    _durationSubscription.cancel();
-    _positionSubscription.cancel();
-    _playerStateSubscription.cancel();
-
-    // Dispose the audio player.
-
-    _player.dispose();
-
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    if (_failedToLoad) {
+      return const Center(child: Text('Audio not found'));
+    }
+    if (!_initialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
     final isPlaying = _playerState == PlayerState.playing;
-    final int durationMs = _duration?.inMilliseconds ?? 0;
-    final int positionMs = _position.inMilliseconds;
+    final isPaused = _playerState == PlayerState.paused;
+    final isStopped = _playerState == PlayerState.stopped;
+    final isCompleted = _playerState == PlayerState.completed;
+
+    final totalMs = _duration?.inMilliseconds ?? 0;
+    final currentMs = _position.inMilliseconds.clamp(0, totalMs);
 
     return Center(
       child: FractionallySizedBox(
         widthFactor: contentWidthFactor,
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            // Progress bar.
-
             Slider(
-              // Prevent errors when positionMs > durationMs by clamping.
-
-              value: positionMs.clamp(0, durationMs).toDouble(),
+              value: currentMs.toDouble(),
               min: 0.0,
-              max: durationMs > 0 ? durationMs.toDouble() : 1.0,
+              max: totalMs > 0 ? totalMs.toDouble() : 1.0,
               onChanged: (double value) {
-                // If durationMs is not loaded yet (=0), prevent dragging.
-
-                if (durationMs > 0) {
+                if (totalMs > 0) {
                   final newPosition = Duration(milliseconds: value.toInt());
                   _player.seek(newPosition);
                 }
               },
             ),
-
-            // Button row.
-
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                // Play/pause button.
-
                 IconButton(
-                  icon: Icon(
-                    isPlaying ? Icons.pause : Icons.play_arrow,
-                  ),
+                  icon: Icon(isPlaying ? Icons.pause : Icons.play_arrow),
                   onPressed: () async {
                     if (isPlaying) {
                       await _player.pause();
                     } else {
-                      if (_playerState == PlayerState.paused ||
-                          _playerState == PlayerState.stopped ||
-                          _playerState == PlayerState.completed) {
+                      if (isPaused) {
                         await _player.resume();
                       } else {
-                        await _player.resume();
+                        // If stopped, completed, or never started,
+                        // play from the start.
+
+                        if (_sourcePath != null) {
+                          await _player.play(DeviceFileSource(_sourcePath!));
+                        }
                       }
                     }
                   },
                 ),
-
-                // Stop button.
-
                 IconButton(
                   icon: const Icon(Icons.stop),
-                  onPressed: () {
-                    _player.stop();
+                  onPressed: () async {
+                    await _player.stop();
                     setState(() {
                       _position = Duration.zero;
                     });

--- a/lib/src/widgets/image_widget.dart
+++ b/lib/src/widgets/image_widget.dart
@@ -30,13 +30,16 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:path_provider/path_provider.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
     show contentWidthFactor, mediaPath;
 
-class ImageWidget extends StatelessWidget {
+class ImageWidget extends StatefulWidget {
   final String filename;
   final double? width;
   final double? height;
@@ -49,27 +52,60 @@ class ImageWidget extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    // Build the local raw path by concatenating mediaPath + filename.
+  ImageWidgetState createState() => ImageWidgetState();
+}
 
-    final String rawLocalPath = '$mediaPath/$filename';
+class ImageWidgetState extends State<ImageWidget> {
+  String? _localPath;
+  bool _failedToLoad = false;
 
-    // Convert it to an OS path (without file://).
+  @override
+  void initState() {
+    super.initState();
+    _initializeImage();
+  }
 
-    String localPath;
-    if (rawLocalPath.startsWith('file://')) {
-      localPath = Uri.parse(rawLocalPath).toFilePath();
+  Future<void> _initializeImage() async {
+    final rawLocalPath = '$mediaPath/${widget.filename}';
+    final file = File(rawLocalPath);
+    final existsLocally = await file.exists();
+
+    if (existsLocally) {
+      _localPath = file.path;
     } else {
-      localPath = rawLocalPath;
+      try {
+        final data = await rootBundle.load(rawLocalPath);
+        final bytes = data.buffer.asUint8List();
+        final tempDir = await getTemporaryDirectory();
+        final fileNameOnly = widget.filename.split('/').last;
+        final tempPath = '${tempDir.path}/$fileNameOnly';
+
+        final tempFile = File(tempPath);
+        await tempFile.writeAsBytes(bytes);
+        _localPath = tempFile.path;
+      } catch (e) {
+        _failedToLoad = true;
+      }
     }
 
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failedToLoad) {
+      return const Center(child: Text('Image not found'));
+    }
+    if (_localPath == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
     return Center(
       child: FractionallySizedBox(
         widthFactor: contentWidthFactor,
         child: Image.file(
-          File(localPath),
-          width: width,
-          height: height,
+          File(_localPath!),
+          width: widget.width,
+          height: widget.height,
           fit: BoxFit.contain,
           errorBuilder: (context, error, stackTrace) {
             return const Text('Image not found');

--- a/lib/src/widgets/image_widget.dart
+++ b/lib/src/widgets/image_widget.dart
@@ -67,9 +67,12 @@ class ImageWidgetState extends State<ImageWidget> {
   Future<void> _initializeImage() async {
     final rawLocalPath = '$mediaPath/${widget.filename}';
     final file = File(rawLocalPath);
-    final existsLocally = await file.exists();
+    final isFileExists = await file.exists();
 
-    if (existsLocally) {
+    final isAssetLike = rawLocalPath.startsWith('assets/') ||
+        rawLocalPath.startsWith('assets\\');
+
+    if (isFileExists && !isAssetLike) {
       _localPath = file.path;
     } else {
       try {

--- a/lib/src/widgets/image_widget.dart
+++ b/lib/src/widgets/image_widget.dart
@@ -30,7 +30,6 @@
 library;
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;

--- a/lib/src/widgets/video_widget.dart
+++ b/lib/src/widgets/video_widget.dart
@@ -29,10 +29,15 @@
 /// Authors: Tony Chen
 library;
 
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
+import 'package:path_provider/path_provider.dart';
 
 import 'package:markdown_widget_builder/src/constants/pkg.dart'
     show contentWidthFactor, mediaPath;
@@ -64,25 +69,37 @@ class _VideoWidgetState extends State<VideoWidget> {
   }
 
   Future<void> _initializeVideo() async {
-    // Build the raw local path by concatenating mediaPath + filename.
+    final rawLocalPath = '$mediaPath/${widget.filename}';
+    final localFile = File(rawLocalPath);
+    final isLocalFile = await localFile.exists();
 
-    final String rawLocalPath = '$mediaPath/${widget.filename}';
+    String mediaUri;
+    if (isLocalFile) {
+      if (rawLocalPath.startsWith('file://')) {
+        mediaUri = rawLocalPath;
+      } else {
+        mediaUri = 'file://$rawLocalPath';
+      }
+    } else {
+      final data = await rootBundle.load(rawLocalPath);
+      final bytes = data.buffer.asUint8List();
 
-    // Convert to a 'file://' URI so media_kit treats it as a local file,
-    // not a Flutter asset.
+      final tempDirPath = (await getTemporaryDirectory()).path;
+      final fileNameOnly = widget.filename.split('/').last;
+      final tempPath = '$tempDirPath/$fileNameOnly';
 
-    final String fileUri = rawLocalPath.startsWith('file://')
-        ? rawLocalPath
-        : 'file://$rawLocalPath';
+      final tempFile = File(tempPath);
+      await tempFile.writeAsBytes(bytes);
 
-    // Initialise the player.
+      mediaUri = Uri.file(tempFile.path).toString();
+    }
 
     _player = Player();
     _controller = VideoController(_player);
 
     // Open the video.
 
-    await _player.open(Media(fileUri), play: false);
+    await _player.open(Media(mediaUri), play: false);
 
     // Set video initialised.
 

--- a/lib/src/widgets/video_widget.dart
+++ b/lib/src/widgets/video_widget.dart
@@ -72,16 +72,17 @@ class _VideoWidgetState extends State<VideoWidget> {
   Future<void> _initializeVideo() async {
     final rawLocalPath = '$mediaPath/${widget.filename}';
     final localFile = File(rawLocalPath);
-    final isLocalFile = await localFile.exists();
+    final isFileExists = await localFile.exists();
+
+    final isAssetLike = rawLocalPath.startsWith('assets/') ||
+        rawLocalPath.startsWith('assets\\');
 
     String mediaUri;
     try {
-      if (isLocalFile) {
-        if (rawLocalPath.startsWith('file://')) {
-          mediaUri = rawLocalPath;
-        } else {
-          mediaUri = 'file://$rawLocalPath';
-        }
+      if (isFileExists && !isAssetLike) {
+        mediaUri = rawLocalPath.startsWith('file://')
+            ? Uri.parse(rawLocalPath).toFilePath()
+            : rawLocalPath;
       } else {
         final ByteData data = await rootBundle.load(rawLocalPath);
         final Uint8List bytes = data.buffer.asUint8List();

--- a/lib/src/widgets/video_widget.dart
+++ b/lib/src/widgets/video_widget.dart
@@ -55,6 +55,7 @@ class _VideoWidgetState extends State<VideoWidget> {
   late final Player _player;
   late final VideoController _controller;
   bool _isVideoInitialized = false;
+  bool _failedToLoad = false;
 
   @override
   void initState() {
@@ -74,47 +75,55 @@ class _VideoWidgetState extends State<VideoWidget> {
     final isLocalFile = await localFile.exists();
 
     String mediaUri;
-    if (isLocalFile) {
-      if (rawLocalPath.startsWith('file://')) {
-        mediaUri = rawLocalPath;
+    try {
+      if (isLocalFile) {
+        if (rawLocalPath.startsWith('file://')) {
+          mediaUri = rawLocalPath;
+        } else {
+          mediaUri = 'file://$rawLocalPath';
+        }
       } else {
-        mediaUri = 'file://$rawLocalPath';
+        final ByteData data = await rootBundle.load(rawLocalPath);
+        final Uint8List bytes = data.buffer.asUint8List();
+
+        final tempDirPath = (await getTemporaryDirectory()).path;
+        final fileNameOnly = widget.filename.split('/').last;
+        final tempPath = '$tempDirPath/$fileNameOnly';
+
+        final tempFile = File(tempPath);
+        await tempFile.writeAsBytes(bytes);
+
+        mediaUri = Uri.file(tempFile.path).toString();
       }
-    } else {
-      final data = await rootBundle.load(rawLocalPath);
-      final bytes = data.buffer.asUint8List();
-
-      final tempDirPath = (await getTemporaryDirectory()).path;
-      final fileNameOnly = widget.filename.split('/').last;
-      final tempPath = '$tempDirPath/$fileNameOnly';
-
-      final tempFile = File(tempPath);
-      await tempFile.writeAsBytes(bytes);
-
-      mediaUri = Uri.file(tempFile.path).toString();
+    } catch (e) {
+      _failedToLoad = true;
+      setState(() {});
+      return;
     }
 
     _player = Player();
     _controller = VideoController(_player);
 
-    // Open the video.
-
-    await _player.open(Media(mediaUri), play: false);
-
-    // Set video initialised.
-
-    setState(() {
-      _isVideoInitialized = true;
-    });
+    try {
+      await _player.open(Media(mediaUri), play: false);
+      setState(() {
+        _isVideoInitialized = true;
+      });
+    } catch (_) {
+      _failedToLoad = true;
+      setState(() {});
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_isVideoInitialized) {
-      return _buildVideoPlayer();
-    } else {
-      return Center(child: CircularProgressIndicator());
+    if (_failedToLoad) {
+      return const Center(child: Text('Video not found'));
     }
+    if (!_isVideoInitialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return _buildVideoPlayer();
   }
 
   Widget _buildVideoPlayer() {
@@ -122,8 +131,6 @@ class _VideoWidgetState extends State<VideoWidget> {
       child: FractionallySizedBox(
         widthFactor: contentWidthFactor,
         child: AspectRatio(
-          // Default aspect ratio.
-
           aspectRatio: 16 / 9,
           child: Focus(
             canRequestFocus: false,


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixed the issue that video cannot be played if the file is in `assets` folder.
- Fixed the issue that audio file cannot be played a second time.
- Fixed the file access permission issue on macOS.

- Link to associated issue: #76 and #77.

- **Please note that the app is in the `example` folder and `flutter create .` should be run first.**

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [x] MacOS
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev